### PR TITLE
feat: add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Dependency directories
+node_modules/
+.next/
+out/
+
+# Environment files
+.env.local
+.env.development
+.env.test
+.env.production
+
+# Build files
+build/
+dist/
+
+# IDE files
+.vscode/
+.idea/
+
+# Miscellaneous
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Next.js
+/.next
+/.next/
+out/


### PR DESCRIPTION
This Pull Request introduces a .gitignore file specifically tailored for a Next.js project. The purpose of this file is to ensure that certain files and directories generated by our development environment, build process, or the Next.js framework itself, are not tracked by Git. This helps keep our repository clean and prevents unnecessary files from being committed.

The .gitignore file includes rules to ignore:

- node_modules/: The directory where Node.js dependencies are installed.
- .next/: The directory where Next.js stores its build output.
- .env.local, .env.development, and .env.production: Environment files that may contain sensitive information.
- npm-debug.log or yarn-error.log: Error log files generated by npm or yarn.
- .DS_Store: A file that Mac OS creates in each directory.